### PR TITLE
Fix Ruff lint failures

### DIFF
--- a/artlink/artifact.py
+++ b/artlink/artifact.py
@@ -8,13 +8,13 @@ from ccflow.base import BaseModel
 from pydantic import ConfigDict, Field, ValidationError, field_serializer, field_validator, model_validator
 
 __all__ = (
-    "ArtlinkError",
-    "ManifestError",
-    "Digest",
-    "Capability",
-    "ArtifactInferenceIssue",
-    "Reference",
     "Artifact",
+    "ArtifactInferenceIssue",
+    "ArtlinkError",
+    "Capability",
+    "Digest",
+    "ManifestError",
+    "Reference",
     "artifact_inference_issues",
     "capability_from_value",
     "has_capability",
@@ -199,7 +199,7 @@ class Artifact(_ManifestModel):
         return tuple(value)
 
     @model_validator(mode="after")
-    def _validate_location(self) -> "Artifact":
+    def _validate_location(self) -> Artifact:
         if self.path is None and not self.uri:
             raise ValueError("artifact must declare a path or uri")
         return self

--- a/artlink/examples/domains/docs.py
+++ b/artlink/examples/domains/docs.py
@@ -13,9 +13,9 @@ from ...registry import ArtifactRegistry
 from ...resolver import ResolutionPlan
 
 __all__ = (
-    "ToolRequirement",
     "DocumentationSiteCollection",
     "DocumentationSiteScheme",
+    "ToolRequirement",
 )
 
 

--- a/artlink/examples/domains/hdl.py
+++ b/artlink/examples/domains/hdl.py
@@ -21,9 +21,9 @@ from ...registry import ArtifactRegistry
 from ...resolver import ResolutionPlan
 
 __all__ = (
-    "ToolRequirement",
     "HardwareDesignCollection",
     "HardwareProjectScheme",
+    "ToolRequirement",
 )
 
 

--- a/artlink/examples/domains/ml.py
+++ b/artlink/examples/domains/ml.py
@@ -13,9 +13,9 @@ from ...registry import ArtifactRegistry
 from ...resolver import ResolutionPlan
 
 __all__ = (
-    "ToolRequirement",
     "ModelReleaseCollection",
     "ModelReleaseScheme",
+    "ToolRequirement",
 )
 
 

--- a/artlink/examples/domains/python.py
+++ b/artlink/examples/domains/python.py
@@ -24,9 +24,9 @@ from ...registry import ArtifactRegistry
 from ...resolver import ResolutionPlan
 
 __all__ = (
-    "ToolRequirement",
     "PythonPackageCollection",
     "PythonPackageScheme",
+    "ToolRequirement",
 )
 
 

--- a/artlink/manifest.py
+++ b/artlink/manifest.py
@@ -12,8 +12,8 @@ __all__ = (
     "ARTLINK_MANIFEST_SCHEMA",
     "Manifest",
     "artifact_path",
-    "manifest_from_mapping",
     "load_manifest",
+    "manifest_from_mapping",
     "validate_artifact_files",
 )
 
@@ -61,7 +61,7 @@ class Manifest(_ManifestModel):
         return self
 
     @classmethod
-    def compose(cls, *, name: str, manifests: tuple["Manifest", ...], intent: str = "", metadata: dict[str, Any] | None = None) -> "Manifest":
+    def compose(cls, *, name: str, manifests: tuple[Manifest, ...], intent: str = "", metadata: dict[str, Any] | None = None) -> Manifest:
         composed_metadata = dict(metadata or {})
         composed_metadata.setdefault("composed_from", [manifest.name for manifest in manifests])
         artifacts = tuple(artifact for manifest in manifests for artifact in manifest.artifacts)

--- a/artlink/materialize.py
+++ b/artlink/materialize.py
@@ -13,9 +13,9 @@ from .registry import ArtifactRegistry, ArtifactRegistryEntry, RegistryError
 from .resolver import ResolutionPlan
 
 __all__ = (
+    "MaterializationAction",
     "MaterializationError",
     "MaterializationMethod",
-    "MaterializationAction",
     "MaterializationPlan",
     "MaterializationResult",
     "build_materialization_plan",

--- a/artlink/registry.py
+++ b/artlink/registry.py
@@ -15,15 +15,15 @@ from .manifest import ARTLINK_MANIFEST_SCHEMA, Manifest, load_manifest
 from .template import Template, load_template
 
 __all__ = (
-    "ARTLINK_REGISTRY_SCHEMA",
     "ARTLINK_INSTALL_SUBDIR",
     "ARTLINK_MANIFEST_ENTRY_POINT_GROUP",
+    "ARTLINK_REGISTRY_SCHEMA",
     "MANIFEST_INSTALL_SUBDIR",
-    "RegistryError",
-    "ManifestRegistryEntry",
-    "TemplateRegistryEntry",
-    "ArtifactRegistryEntry",
     "ArtifactRegistry",
+    "ArtifactRegistryEntry",
+    "ManifestRegistryEntry",
+    "RegistryError",
+    "TemplateRegistryEntry",
     "artlink_install_dir",
     "load_registry",
     "manifest_install_dir",
@@ -102,7 +102,7 @@ class ArtifactRegistry(_ArtlinkModel):
         source: str = "explicit",
         root: Path | None = None,
         allow_manifest_versions: bool = False,
-    ) -> "ArtifactRegistry":
+    ) -> ArtifactRegistry:
         registry = cls(allow_manifest_versions=allow_manifest_versions)
         for manifest in manifests:
             registry.register_manifest(manifest, source=source, root=root)
@@ -116,17 +116,17 @@ class ArtifactRegistry(_ArtlinkModel):
         source: str | None = None,
         root: Path | None = None,
         allow_manifest_versions: bool = False,
-    ) -> "ArtifactRegistry":
+    ) -> ArtifactRegistry:
         registry = cls(allow_manifest_versions=allow_manifest_versions)
         for path in paths:
             registry.register_manifest_file(path, source=source, root=root)
         return registry
 
     @classmethod
-    def from_install_path(cls, root: Path | None = None, *, allow_manifest_versions: bool = False) -> "ArtifactRegistry":
+    def from_install_path(cls, root: Path | None = None, *, allow_manifest_versions: bool = False) -> ArtifactRegistry:
         return cls(allow_manifest_versions=allow_manifest_versions).discover_install_path(root)
 
-    def register_manifest(self, manifest: Manifest, *, source: str = "explicit", root: Path | None = None) -> "ArtifactRegistry":
+    def register_manifest(self, manifest: Manifest, *, source: str = "explicit", root: Path | None = None) -> ArtifactRegistry:
         manifest_key = (manifest.name, manifest.version)
         registration_root = Path(root) if root is not None else None
         if manifest_key in self._manifests or (not self.allow_manifest_versions and self._entries_for_name(manifest.name)):
@@ -136,13 +136,13 @@ class ArtifactRegistry(_ArtlinkModel):
             self.register_artifact(artifact, source=source, manifest_name=manifest.name, manifest_version=manifest.version, root=registration_root)
         return self
 
-    def register_manifest_file(self, path: Path, *, source: str | None = None, root: Path | None = None) -> "ArtifactRegistry":
+    def register_manifest_file(self, path: Path, *, source: str | None = None, root: Path | None = None) -> ArtifactRegistry:
         manifest_path = Path(path)
         manifest_source = source or manifest_path.as_posix()
         registration_root = manifest_path.parent if root is None else Path(root)
         return self.register_manifest(load_manifest(manifest_path), source=manifest_source, root=registration_root)
 
-    def register_template(self, template: Template, *, source: str = "explicit", root: Path | None = None) -> "ArtifactRegistry":
+    def register_template(self, template: Template, *, source: str = "explicit", root: Path | None = None) -> ArtifactRegistry:
         template_key = (template.name, template.version)
         registration_root = Path(root) if root is not None else None
         if template_key in self._templates or (not self.allow_template_versions and self._template_entries_for_name(template.name)):
@@ -150,7 +150,7 @@ class ArtifactRegistry(_ArtlinkModel):
         self._templates[template_key] = TemplateRegistryEntry(template=template, source=source, root=registration_root)
         return self
 
-    def register_template_file(self, path: Path, *, source: str | None = None, root: Path | None = None) -> "ArtifactRegistry":
+    def register_template_file(self, path: Path, *, source: str | None = None, root: Path | None = None) -> ArtifactRegistry:
         template_path = Path(path)
         template_source = source or template_path.as_posix()
         registration_root = template_path.parent if root is None else Path(root)
@@ -164,7 +164,7 @@ class ArtifactRegistry(_ArtlinkModel):
         manifest_name: str = "",
         manifest_version: str = "",
         root: Path | None = None,
-    ) -> "ArtifactRegistry":
+    ) -> ArtifactRegistry:
         registration_root = Path(root) if root is not None else None
         self._artifacts.append(
             ArtifactRegistryEntry(
@@ -177,7 +177,7 @@ class ArtifactRegistry(_ArtlinkModel):
         )
         return self
 
-    def discover_install_path(self, root: Path | None = None) -> "ArtifactRegistry":
+    def discover_install_path(self, root: Path | None = None) -> ArtifactRegistry:
         install_prefix = _install_prefix(root)
         return self.discover_manifest_files(artlink_install_dir(install_prefix))
 
@@ -187,7 +187,7 @@ class ArtifactRegistry(_ArtlinkModel):
         *,
         patterns: tuple[str, ...] = _MANIFEST_FILE_PATTERNS,
         root: Path | None = None,
-    ) -> "ArtifactRegistry":
+    ) -> ArtifactRegistry:
         manifest_dir = Path(directory)
         if not manifest_dir.exists():
             return self
@@ -207,7 +207,7 @@ class ArtifactRegistry(_ArtlinkModel):
         *,
         group: str = ARTLINK_MANIFEST_ENTRY_POINT_GROUP,
         entry_points: Any | None = None,
-    ) -> "ArtifactRegistry":
+    ) -> ArtifactRegistry:
         for entry_point in _select_entry_points(group=group, entry_points=entry_points):
             source = f"entry-point:{entry_point.name}"
             value = entry_point.load()

--- a/artlink/resolver.py
+++ b/artlink/resolver.py
@@ -12,12 +12,12 @@ from .registry import ArtifactRegistry, ManifestRegistryEntry, RegistryError, Te
 from .template import Template
 
 __all__ = (
-    "ResolutionError",
-    "ProviderConflictPolicy",
     "CapabilityProvider",
+    "ProviderConflictPolicy",
+    "ResolutionEdge",
+    "ResolutionError",
     "ResolutionIssue",
     "ResolutionNode",
-    "ResolutionEdge",
     "ResolutionPlan",
     "resolve_manifest",
 )

--- a/artlink/template.py
+++ b/artlink/template.py
@@ -12,15 +12,15 @@ from .manifest import Manifest
 
 __all__ = (
     "ARTLINK_TEMPLATE_SCHEMA",
-    "TemplateError",
     "ArtifactSelector",
     "Cardinality",
+    "Template",
+    "TemplateError",
     "TemplateRule",
     "ValidationIssue",
     "ValidationResult",
-    "Template",
-    "template_from_mapping",
     "load_template",
+    "template_from_mapping",
 )
 
 
@@ -113,9 +113,7 @@ class Cardinality(_TemplateModel):
     def allows(self, count: int) -> bool:
         if count < self.min:
             return False
-        if self.max is not None and count > self.max:
-            return False
-        return True
+        return not (self.max is not None and count > self.max)
 
     def describe_failure(self, count: int) -> str:
         if count < self.min:
@@ -218,7 +216,7 @@ class Template(_TemplateModel):
         return yaml.safe_dump(self.model_dump(mode="json"), sort_keys=False)
 
     @classmethod
-    def load(cls, path: Path) -> "Template":
+    def load(cls, path: Path) -> Template:
         return load_template(path)
 
 

--- a/artlink/tests/integration/test_python_profile.py
+++ b/artlink/tests/integration/test_python_profile.py
@@ -36,8 +36,7 @@ packages = ["src/demo_pkg"]
         [sys.executable, "-m", "build", "--sdist", "--wheel", "--no-isolation", "--outdir", "dist"],
         cwd=project_root,
         check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
 

--- a/artlink/tests/test_all.py
+++ b/artlink/tests/test_all.py
@@ -1,4 +1,4 @@
-from artlink import *  # noqa
+from artlink import *
 
 
 def test_all():


### PR DESCRIPTION
## Description

Update Python code for current Ruff findings without changing lint configuration. Sort exported names, modernize annotations, simplify cardinality validation, and use `capture_output` in integration tests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [ ] New tests added for new functionality (not applicable; behavior unchanged)
- [ ] Documentation updated (not applicable)
- [ ] Changelog / version bump (not applicable)